### PR TITLE
Fix retrieving download links

### DIFF
--- a/kissanime.js
+++ b/kissanime.js
@@ -3,7 +3,7 @@
 
 // CONFIG
 var siteName = "Kissanime"
-var rootUrl = 'http://kissanime.com'
+var rootUrl = 'http://kissanime.ru'
 var URL = window.location.origin
 // END CONFIG
 
@@ -11,6 +11,23 @@ var URL = window.location.origin
 var episodeLinks = $('table.listing a').map(function(i,el) { return $(el).attr('href'); });
 var episodeNames = $('table.listing a').map(function(i,el) { return $.trim( $(el).html() ); });
 
+<<<<<<< HEAD
+=======
+$.ajaxSetup({async:false});
+$.getScript(rootUrl + "/Scripts/asp.js");
+
+var jsS = [
+	"/Scripts/css.js",
+	"/Scripts/vr.js",
+	"/Scripts/shal.js",
+];
+console.log('Loading scripts ...');
+for (var i=0; i < jsS.length; i++){
+	console.log(jsS[i]);
+	$.getScript(rootUrl + jsS[i]);
+}
+
+>>>>>>> a5df757... Fix retrieving download links
 console.log('Starting ' + siteName + ' Batch Downloader script...');
 
 $.ajaxSetup({async:false});
@@ -92,6 +109,7 @@ $.getScript(rootUrl + "/Scripts/css.js", function(){
 							var links = $(ovelWrap(scriptCheck[1])).filter("a");
 						}
 
+<<<<<<< HEAD
 						var quals = videoQuality.split(',');
 						var found = false;
 						// pick download
@@ -117,6 +135,56 @@ $.getScript(rootUrl + "/Scripts/css.js", function(){
 									console.log(long_url);
 								}
 							});
+=======
+for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEpisode); i--) {
+	console.log('Fetching listing ' + (episodeLinks.length - i) + ' [' + episodeNames[i] + ']');
+	jQuery.ajax({
+		url: URL + episodeLinks[i], 
+		tryCount : 0,
+		retryLimit : 3,
+		success: function(result) {
+			var $result = eval($(result));
+			
+			// console.log(result.search("Save link as"));
+			// console.log(result.search("divDownload"));
+
+			var data = $(result).find("#divDownload");
+
+			if (data == null || data == "" || data.length == 0){ // captcha maybe
+				console.log("Captcha detected at " + URL + episodeLinks[i]);
+				prompt("Captcha detected. Solve it by opening the link below in a new tab. After solving, press OK.",
+					defaultText=URL + episodeLinks[i]);
+				this.tryCount++;
+				$.ajax(this);  // retry
+				return;
+			}
+			// console.log(links);
+			
+			var scriptCheck = result.match(/id="divDownload">(?:(?:.|\n|\r)*?)document\.write\(ovelWrap\('(.*?)'\)\);/);
+						
+			if(scriptCheck)
+				var links = $(ovelWrap(scriptCheck[1])).filter("a");
+			
+			var quals = videoQuality.split(',');
+			var found = false;
+			// pick download
+			for (var j=0; j<quals.length; j++){
+				// check if the format exists or not
+				if (found)
+					return;
+
+				$.each(links, function(index, el) {
+					// console.log(el);
+					if ( $(el).html().search(quals[j]) > -1 ){
+						long_url = $(el).attr('href');
+						name = getDownloadName(episodeNames[i], $(el).html());
+						if (opOptions == "1"){
+							linkStr += encodeURI(long_url) + " " + name + "\n";
+						} else if (opOptions == "2"){
+							linkStr += '<a href="' + long_url + '" download="' + name + '">' + name + '</a><br>';
+						} else {
+							linkStr += long_url + "\n";
+>>>>>>> a5df757... Fix retrieving download links
 						}
 						// successful response processed
 					},

--- a/kissanime.js
+++ b/kissanime.js
@@ -11,126 +11,137 @@ var URL = window.location.origin
 var episodeLinks = $('table.listing a').map(function(i,el) { return $(el).attr('href'); });
 var episodeNames = $('table.listing a').map(function(i,el) { return $.trim( $(el).html() ); });
 
-$.ajaxSetup({async:false});
-$.getScript(rootUrl + "/Scripts/asp.js");
-
 console.log('Starting ' + siteName + ' Batch Downloader script...');
 
-var startEpisode;
-do {
-	startEpisode = Number(prompt("Enter episode (listing) number you want to start from", defaultText="1"));
-	if(startEpisode <= 0 || startEpisode > episodeLinks.length) {
-		alert("Episode number entered must be greater than 0 and lesser than total number of eps"); 
-	} else {
-		break; 
-	}
-} while(true);
+$.ajaxSetup({async:false});
+$.getScript(rootUrl + "/Scripts/asp.js");
+$.getScript(rootUrl + "/Scripts/css.js", function(){
+	$.getScript(rootUrl + "/Scripts/vr.js", function(){
+		$.getScript(rootUrl + "/Scripts/shal.js", function(){
+			var startEpisode;
+			do {
+				startEpisode = Number(prompt("Enter episode (listing) number you want to start from", defaultText="1"));
+				if(startEpisode <= 0 || startEpisode > episodeLinks.length) {
+					alert("Episode number entered must be greater than 0 and lesser than total number of eps"); 
+				} else {
+					break; 
+				}
+			} while(true);
 
-var endEpisode;
-do {
-	endEpisode = Number(prompt("Enter episode (listing) number you want to end at", defaultText="2"));
-	if(endEpisode <= 0 || endEpisode > episodeLinks.length || endEpisode < startEpisode) {
-		alert("Episode number entered must be greater than 0 and lesser than total number of eps");
-	} else {
-		break;
-	}
-} while(true);
+			var endEpisode;
+			do {
+				endEpisode = Number(prompt("Enter episode (listing) number you want to end at", defaultText="2"));
+				if(endEpisode <= 0 || endEpisode > episodeLinks.length || endEpisode < startEpisode) {
+					alert("Episode number entered must be greater than 0 and lesser than total number of eps");
+				} else {
+					break;
+				}
+			} while(true);
 
-var videoQuality = prompt(
-	"Enter video quality preferences for the download. Example - '720,480'\nThis first looks for 720p, if 720 is not available, it picks 480.", 
-	defaultText="720,480"
-);
+			var videoQuality = prompt(
+				"Enter video quality preferences for the download. Example - '720,480'\nThis first looks for 720p, if 720 is not available, it picks 480.", 
+				defaultText="720,480"
+			);
 
-if (videoQuality == null){
-	videoQuality = "720,480,360";
-}
-
-var opOptions = prompt(
-	"How do you want output to be?\n0 = simple list of links\n1 = List with filenames (for wget, aria2 helper scripts)\n2 = HTML page with links",
-	defaultText="0"
-);
-
-if (opOptions == null){
-	opOptions = "0";
-}
-
-var i;
-var linkStr = "";
-
-console.log('Starting to fetch links..');
-
-for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEpisode); i--) {
-	console.log('Fetching listing ' + (episodeLinks.length - i) + ' [' + episodeNames[i] + ']');
-	jQuery.ajax({
-		url: URL + episodeLinks[i], 
-		tryCount : 0,
-		retryLimit : 3,
-		success: function(result) {
-			var $result = eval($(result));
-			
-			// console.log(result.search("Save link as"));
-			// console.log(result.search("divDownload"));
-
-			var data = $(result).find("#divDownload");  // download data
-			var links = $(data[0]).find("a");
-
-			if (data == null || data == "" || data.length == 0){ // captcha maybe
-				console.log("Captcha detected at " + URL + episodeLinks[i]);
-				prompt("Captcha detected. Solve it by opening the link below in a new tab. After solving, press OK.",
-					defaultText=URL + episodeLinks[i]);
-				this.tryCount++;
-				$.ajax(this);  // retry
-				return;
+			if (videoQuality == null){
+				videoQuality = "720,480,360";
 			}
-			// console.log(links);
-			
-			var quals = videoQuality.split(',');
-			var found = false;
-			// pick download
-			for (var j=0; j<quals.length; j++){
-				// check if the format exists or not
-				if (found)
-					return;
 
-				$.each(links, function(index, el) {
-					// console.log(el);
-					if ( $(el).html().search(quals[j]) > -1 ){
-						long_url = $(el).attr('href');
-						name = getDownloadName(episodeNames[i], $(el).html());
-						if (opOptions == "1"){
-							linkStr += encodeURI(long_url) + " " + name + "\n";
-						} else if (opOptions == "2"){
-							linkStr += '<a href="' + long_url + '" download="' + name + '">' + name + '</a><br>';
-						} else {
-							linkStr += long_url + "\n";
+			var opOptions = prompt(
+				"How do you want output to be?\n0 = simple list of links\n1 = List with filenames (for wget, aria2 helper scripts)\n2 = HTML page with links",
+				defaultText="0"
+			);
+
+			if (opOptions == null){
+				opOptions = "0";
+			}
+
+			var i;
+			var linkStr = "";
+
+			console.log('Starting to fetch links..');
+
+			for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEpisode); i--) {
+				console.log('Fetching listing ' + (episodeLinks.length - i) + ' [' + episodeNames[i] + ']');
+				jQuery.ajax({
+					url: URL + episodeLinks[i], 
+					tryCount : 0,
+					retryLimit : 3,
+					success: function(result) {
+						var $result = eval($(result));
+
+						// console.log(result.search("Save link as"));
+						// console.log(result.search("divDownload"));
+
+						var data = $(result).find("#divDownload");  // download data
+						var links = $(data[0]).find("a");
+
+						if (data == null || data == "" || data.length == 0){ // captcha maybe
+							console.log("Captcha detected at " + URL + episodeLinks[i]);
+							prompt("Captcha detected. Solve it by opening the link below in a new tab. After solving, press OK.",
+								defaultText=URL + episodeLinks[i]);
+							this.tryCount++;
+							$.ajax(this);  // retry
+							return;
 						}
-						found = true;
-						// console.log('Episode ' + (episodeLinks.length - i));
-						console.log(long_url);
-					}
+						// console.log(links);
+
+						var scriptCheck = result.match(/id="divDownload">(?:(?:.|\n|\r)*?)document\.write\(ovelWrap\('(.*?)'\)\);/);
+						
+						if(scriptCheck){
+							var links = $(ovelWrap(scriptCheck[1])).filter("a");
+						}
+
+						var quals = videoQuality.split(',');
+						var found = false;
+						// pick download
+						for (var j=0; j<quals.length; j++){
+							// check if the format exists or not
+							if (found)
+								return;
+
+							$.each(links, function(index, el) {
+								// console.log(el);
+								if ( $(el).html().search(quals[j]) > -1 ){
+									long_url = $(el).attr('href');
+									name = getDownloadName(episodeNames[i], $(el).html());
+									if (opOptions == "1"){
+										linkStr += encodeURI(long_url) + " " + name + "\n";
+									} else if (opOptions == "2"){
+										linkStr += '<a href="' + long_url + '" download="' + name + '">' + name + '</a><br>';
+									} else {
+										linkStr += long_url + "\n";
+									}
+									found = true;
+									// console.log('Episode ' + (episodeLinks.length - i));
+									console.log(long_url);
+								}
+							});
+						}
+						// successful response processed
+					},
+					error: function(xhr, textStatus, errorThrown ) {
+						console.log(textStatus)
+						// http://stackoverflow.com/questions/10024469/whats-the-best-way-to-retry-an-ajax-request-on-failure-using-jquery
+						this.tryCount++;
+						if (this.tryCount <= this.retryLimit) {
+							//try again
+							console.log('Retrying..');
+							$.ajax(this);
+						}
+						return;
+					},
+					async:   false, 
+					script:  true
 				});
 			}
-			// successful response processed
-		},
-		error: function(xhr, textStatus, errorThrown ) {
-			console.log(textStatus)
-			// http://stackoverflow.com/questions/10024469/whats-the-best-way-to-retry-an-ajax-request-on-failure-using-jquery
-			this.tryCount++;
-			if (this.tryCount <= this.retryLimit) {
-				//try again
-				console.log('Retrying..');
-				$.ajax(this);
-			}
-			return;
-		},
-		async:   false, 
-		script:  true
+
+			console.log('Opening list of links')
+			download("links." + ((opOptions == '2') ? 'html' : 'txt'), (opOptions == '2') ? 'text/html' : 'text/plain', linkStr)
+		});
 	});
-}
-
-console.log('Opening list of links')
-download("links." + ((opOptions == '2') ? 'html' : 'txt'), (opOptions == '2') ? 'text/html' : 'text/plain', linkStr)
-
+});
+			
 // http://ourcodeworld.com/articles/read/189/how-to-create-a-file-and-generate-a-download-with-javascript-in-the-browser-without-a-server
 function download(filename, datatype, text) {
 	var element = document.createElement('a');


### PR DESCRIPTION
This fixes the bug which the script couldn't retrieve links on KissAnime. KissAnime uses JavaScript to print the download links, which this script didn't know how to deal with it.
css.js, vr.js and shal.js are now included for the decryption of the string containing the download links.

[The diff is like that because of indentation]