### PR TITLE
Fix retrieving download links

### DIFF
--- a/kissanime.js
+++ b/kissanime.js
@@ -15,9 +15,10 @@ $.ajaxSetup({async:false});
 $.getScript(rootUrl + "/Scripts/asp.js");
 
 var jsS = [
+	"/Scripts/google.js",
 	"/Scripts/css.js",
-	"/Scripts/vr.js",
-	"/Scripts/shal.js",
+	"/Scripts/vr.js?v=1",
+	// "/Scripts/shal.js",
 ];
 console.log('Loading scripts ...');
 for (var i=0; i < jsS.length; i++){
@@ -96,8 +97,8 @@ for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEp
 			// console.log(links);
 			
 			var scriptCheck = result.match(/id="divDownload">(?:(?:.|\n|\r)*?)document\.write\(ovelWrap\('(.*?)'\)\);/);
-						
-			if(scriptCheck)
+		
+			if (scriptCheck)
 				var links = $(ovelWrap(scriptCheck[1])).filter("a");
 			
 			var quals = videoQuality.split(',');
@@ -139,7 +140,7 @@ for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEp
 			}
 			return;
 		},
-		async:   false, 
+		async:   false,
 		script:  true
 	});
 }

--- a/kissanime.js
+++ b/kissanime.js
@@ -3,7 +3,7 @@
 
 // CONFIG
 var siteName = "Kissanime"
-var rootUrl = 'http://kissanime.com'
+var rootUrl = 'http://kissanime.ru'
 var URL = window.location.origin
 // END CONFIG
 
@@ -13,6 +13,17 @@ var episodeNames = $('table.listing a').map(function(i,el) { return $.trim( $(el
 
 $.ajaxSetup({async:false});
 $.getScript(rootUrl + "/Scripts/asp.js");
+
+var jsS = [
+	"/Scripts/css.js",
+	"/Scripts/vr.js",
+	"/Scripts/shal.js",
+];
+console.log('Loading scripts ...');
+for (var i=0; i < jsS.length; i++){
+	console.log(jsS[i]);
+	$.getScript(rootUrl + jsS[i]);
+}
 
 console.log('Starting ' + siteName + ' Batch Downloader script...');
 
@@ -83,6 +94,11 @@ for (i = (episodeLinks.length - startEpisode); i >= (episodeLinks.length - endEp
 				return;
 			}
 			// console.log(links);
+			
+			var scriptCheck = result.match(/id="divDownload">(?:(?:.|\n|\r)*?)document\.write\(ovelWrap\('(.*?)'\)\);/);
+						
+			if(scriptCheck)
+				var links = $(ovelWrap(scriptCheck[1])).filter("a");
 			
 			var quals = videoQuality.split(',');
 			var found = false;


### PR DESCRIPTION
This fixes the bug which the script couldn't retrieve links on KissAnime. KissAnime uses JavaScript to print the download links, which this script didn't know how to deal with it.
css.js, vr.js and shal.js are now included for the decryption of the string containing the download links.